### PR TITLE
Reduce size of output files for pre-2022 maps

### DIFF
--- a/nsw_topo_split/__main__.py
+++ b/nsw_topo_split/__main__.py
@@ -133,6 +133,7 @@ def main() -> None:
     )
     for page in pages:
         writer.add_page(page)
+    writer.compress_identical_objects()
     with open(out_file, "wb") as f:
         writer.write(f)
     reader.close()


### PR DESCRIPTION
Adding the line
https://github.com/tschanzer/nsw-topo-split/blob/c016590076f1ea81e6ef23f705ff6a9ded16e046/nsw_topo_split/__main__.py#L136
reduces the size of the 2017 Katoomba map from 239 MB to 43 MB for me. The original is 14 MB though, so there must still be some duplication.

The program is also pretty slow for the pre-2022 maps -- about 45s for Katoomba 2017 compared to <1s for 2022. The compression step doesn't change this noticeably.

I'll see if I can do any better...