### PR TITLE
Switch from pypdf to pymupdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the Creative Commons Attribution 4.0 license.
 ## Usage
 ```
 usage: python -m nsw_topo_split [-h] [-o OUT] [-s SIZE] [-p] [-n NX NY]
-                                [-l LX LY] [-w] [-f]
+                                [-l LX LY] [-w] [-f] [-d [DPI]]
                                 {map,cover} name year
 
 split a NSW topographic map across smaller pages
@@ -41,14 +41,14 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -o OUT, --out OUT     output directory (default: working directory). Files
+  -o OUT, --out OUT     output directory (default: working directory); files
                         are output in a subdirectory corresponding to the
-                        publication year and map name, e.g., 2022/katoomba.
+                        publication year and map name, e.g., 2022/katoomba
   -s SIZE, --size SIZE  page size (case-insensitive); options are 'A0' through
                         'A10', 'B0' through 'B10', 'C0' through 'C10',
                         'Card-4x6', 'Card-5x7', 'Commercial', 'Executive',
                         'Invoice', 'Ledger', 'Legal', 'Legal-13', 'Letter',
-                        'Monarch' and 'Tabloid-Extra'.
+                        'Monarch' and 'Tabloid-Extra'
   -p, --portrait        use portrait layout rather than landscape
   -n NX NY, --n-pages NX NY
                         horizontal and vertical number of pages (default: [4,
@@ -61,7 +61,13 @@ options:
                         do not expand overlaps to eliminate white space
   -f, --force-download  download the original map, even if it already exists
                         in the output directory
-
+  -d [DPI], --dpi [DPI]
+                        rasterize the output to the specified resolution
+                        (default: 300 DPI); if this option is not given, then
+                        the output will not be rasterized. WARNING: this may
+                        make gridlines hard to see on some map editions. It
+                        will also increase processing time, and file size for
+                        mode=map.
 ```
 
 For example, the [quick example](#quick-example) above will produce three PDFs

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ the Creative Commons Attribution 4.0 license.
 
 ## Usage
 ```
-usage: python -m nsw_topo_split [-h] [-o OUT] [-s SIZE] [-p]
-                                [-n N_PAGES N_PAGES]
-                                [-l OVERLAP OVERLAP] [-w] [-f]
+usage: python -m nsw_topo_split [-h] [-o OUT] [-s SIZE] [-p] [-n NX NY]
+                                [-l LX LY] [-w] [-f]
                                 {map,cover} name year
 
 split a NSW topographic map across smaller pages
@@ -36,27 +35,33 @@ split a NSW topographic map across smaller pages
 positional arguments:
   {map,cover}           'map' to make the map pages, 'cover' to make the cover
                         pages
-  name                  lowercase map name with spaces replaced by underscores,
-                        e.g., mount_wilson
+  name                  lowercase map name with spaces replaced by
+                        underscores, e.g., mount_wilson
   year                  year of publication
 
 options:
   -h, --help            show this help message and exit
-  -o, --out OUT         output directory (default: working directory). Files are
-                        output in a subdirectory corresponding to the
+  -o OUT, --out OUT     output directory (default: working directory). Files
+                        are output in a subdirectory corresponding to the
                         publication year and map name, e.g., 2022/katoomba.
-  -s, --size SIZE       page size (e.g., A4; default A3)
+  -s SIZE, --size SIZE  page size (case-insensitive); options are 'A0' through
+                        'A10', 'B0' through 'B10', 'C0' through 'C10',
+                        'Card-4x6', 'Card-5x7', 'Commercial', 'Executive',
+                        'Invoice', 'Ledger', 'Legal', 'Legal-13', 'Letter',
+                        'Monarch' and 'Tabloid-Extra'.
   -p, --portrait        use portrait layout rather than landscape
-  -n, --n-pages N_PAGES N_PAGES
-                        horizontal and vertical number of pages (default: [4, 3]
-                        for A4, [3, 2] otherwise)
-  -l, --overlap OVERLAP OVERLAP
+  -n NX NY, --n-pages NX NY
+                        horizontal and vertical number of pages (default: [4,
+                        3] for A4 map, [1, 2] for A4 cover, [3, 2] for A3 map,
+                        [1, 1] for A3 cover, otherwise undefined)
+  -l LX LY, --overlap LX LY
                         horizontal and vertical overlap between pages in mm
                         (default: [20, 20])
   -w, --allow-white-space
                         do not expand overlaps to eliminate white space
-  -f, --force-download  download the original map, even if it already exists in
-                        the output directory
+  -f, --force-download  download the original map, even if it already exists
+                        in the output directory
+
 ```
 
 For example, the [quick example](#quick-example) above will produce three PDFs

--- a/nsw_topo_split/__init__.py
+++ b/nsw_topo_split/__init__.py
@@ -174,3 +174,29 @@ def make_cover(docsrc: pymupdf.Document) -> pymupdf.Document:
         ),
     )
     return docout
+
+
+def rasterize(docsrc: pymupdf.Document, dpi: int) -> pymupdf.Document:
+    """
+    Rasterize a PDF by converting its pages to PNG.
+
+    Args:
+        docsrc: Document to be rasterized.
+        dpi: Resolution.
+
+    Returns:
+        Rasterized document.
+    """
+
+    docout = pymupdf.Document()
+    for pagesrc in docsrc:
+        pix: pymupdf.Pixmap = pagesrc.get_pixmap(dpi=dpi)
+        pngbytes = pix.tobytes("png")
+        pngdoc = pymupdf.Document("png", pngbytes)
+        pdfbytes = pngdoc.convert_to_pdf()
+        pdfdoc = pymupdf.Document("pdf", pdfbytes)
+        pageout: pymupdf.Page = docout.new_page(
+            width=pagesrc.bound().width, height=pagesrc.bound().height
+        )
+        pageout.show_pdf_page(pageout.bound(), pdfdoc)
+    return docout

--- a/nsw_topo_split/__main__.py
+++ b/nsw_topo_split/__main__.py
@@ -12,6 +12,7 @@ from nsw_topo_split import (
     map_names_scales,
     mm_to_pt,
     posterize,
+    rasterize,
 )
 
 
@@ -40,9 +41,9 @@ def main() -> None:
         type=pathlib.Path,
         default=pathlib.Path.cwd(),
         help=(
-            "output directory (default: working directory). "
-            "Files are output in a subdirectory corresponding to the "
-            "publication year and map name, e.g., 2022/katoomba."
+            "output directory (default: working directory); "
+            "files are output in a subdirectory corresponding to the "
+            "publication year and map name, e.g., 2022/katoomba"
         ),
     )
     parser.add_argument(
@@ -56,7 +57,7 @@ def main() -> None:
             "page size (case-insensitive); options are  'A0' through 'A10', "
             "'B0' through 'B10', 'C0' through 'C10', 'Card-4x6', 'Card-5x7', "
             "'Commercial', 'Executive', 'Invoice', 'Ledger', 'Legal', 'Legal-13', "
-            "'Letter', 'Monarch' and 'Tabloid-Extra'."
+            "'Letter', 'Monarch' and 'Tabloid-Extra'"
         ),
     )
     parser.add_argument(
@@ -103,6 +104,19 @@ def main() -> None:
             "in the output directory"
         ),
     )
+    parser.add_argument(
+        "-d",
+        "--dpi",
+        type=int,
+        nargs="?",
+        const=300,
+        help=(
+            "rasterize the output to the specified resolution (default: 300 DPI); "
+            "if this option is not given, then the output will not be rasterized. "
+            "WARNING: this may make gridlines hard to see on some map editions. "
+            "It will also increase processing time, and file size for mode=map."
+        ),
+    )
     args = parser.parse_args()
 
     # Get page size in points
@@ -145,7 +159,6 @@ def main() -> None:
             no_white_space=(not args.allow_white_space),
         )
         out_file = (out_dir / (full_name + "_cover_" + args.size)).with_suffix(".pdf")
-        docout.save(out_file)
     else:
         docout = posterize(
             docsrc,
@@ -156,7 +169,10 @@ def main() -> None:
             no_white_space=(not args.allow_white_space),
         )
         out_file = (out_dir / (full_name + "_split_" + args.size)).with_suffix(".pdf")
-        docout.save(out_file)
+
+    if args.dpi is not None:
+        docout = rasterize(docout, args.dpi)
+    docout.ez_save(out_file)
     docsrc.close()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "nsw-topo-split"
 version = "0.1"
 dependencies = [
-    "pypdf",
+    "pymupdf",
 ]
 
 [project.optional-dependencies]
@@ -27,6 +27,11 @@ multi_line_output = 3
 [tool.mypy]
 strict = true
 files = ["nsw_topo_split"]
+
+
+[[tool.mypy.overrides]]
+module = ["pymupdf"]
+ignore_missing_imports = true
 
 [tool.pylint]
 max-line-length = 88

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -53,7 +53,7 @@ pre-commit==4.1.0
     # via nsw-topo-split (pyproject.toml)
 pylint==3.3.3
     # via nsw-topo-split (pyproject.toml)
-pypdf==5.1.0
+pymupdf==1.25.2
     # via nsw-topo-split (pyproject.toml)
 pyproject-hooks==1.2.0
     # via


### PR DESCRIPTION
This fixes #8:
- _map and _cover files are now the same size as the original for all editions
- processing time is much shorter for pre-2022 editions (~45s to ~6s)
- added option to rasterize the output